### PR TITLE
Update podman dependency version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PKG_LICENSE_FILES := LICENSE
 LUCI_TITLE         := LuCI Support for Podman
 LUCI_DESCRIPTION   := Modern web interface for managing Podman containers with auto-update, auto-start, images, volumes, networks, pods, and secrets on OpenWrt
 LUCI_DEPENDS       := +rpcd +rpcd-mod-file
-LUCI_EXTRA_DEPENDS := podman
+LUCI_EXTRA_DEPENDS := podman (>=0)
 LUCI_PKGARCH       := all
 
 include $(TOPDIR)/feeds/luci/luci.mk


### PR DESCRIPTION
Updated Makefile with version constraints for LUCI_EXTRA_DEPENDS to adapt to OpenWrt main branch requirements. Tested on latest OpenWrt main snapshot.