### PR TITLE
Fix rc.d boot-order bug: cap init_start_priority at 99, rename generated init scripts to podman-container-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ If encountering socket errors:
 You can generate a startup script which respects the restart policy set in the container.
 
 > [!TIP]
-> If you want save startup scripts during an upgrade you have to config your `/etc/sysupgrade.conf` with `/etc/init.d/container-*`.
+> If you want save startup scripts during an upgrade you have to config your `/etc/sysupgrade.conf` with `/etc/init.d/podman-container-*`.
 > ```bash
-> echo "/etc/init.d/container-*" >> /etc/sysupgrade.conf
+> echo "/etc/init.d/podman-container-*" >> /etc/sysupgrade.conf
 > ```
 
 ## Container Auto-Update
@@ -148,7 +148,7 @@ The app stores its settings in `/etc/config/luci-podman`:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `init_start_priority` | `100` | procd start priority for container init scripts |
+| `init_start_priority` | `99` | procd start priority for container init scripts (max 99: procd sorts rc.d symlinks as strings, so 100+ breaks ordering) |
 | `socket_path` | `/run/podman/podman.sock` | Path to the Podman API socket |
 
 ## Credits

--- a/root/usr/share/podman/procd-startup-template.sh
+++ b/root/usr/share/podman/procd-startup-template.sh
@@ -49,6 +49,10 @@ start_service() {
 			logger -t ${NAME} 'Container {name} already running'
 		fi
 	"
+	# Bounded retries: if S99podman's tie-break puts it after this script,
+	# the socket wait above may time out on a slow first boot. A capped
+	# respawn gives extra 120s windows without looping forever.
+	procd_set_param respawn 3600 5 5
 	procd_close_instance
 }
 

--- a/root/usr/share/rpcd/ucode/podman.uc
+++ b/root/usr/share/rpcd/ucode/podman.uc
@@ -37,9 +37,14 @@ import {
 
 const uci = cursor();
 const _prio = uci.get('luci-podman', 'globals', 'init_start_priority');
-const INIT_START_PRIORITY = (type(_prio) === 'string' && match(_prio, /^([0-9]|[1-9][0-9]|100)$/)) ? _prio : '100';
+// Capped at 99: procd sorts rc.d symlinks as plain strings, so a 3-digit
+// value like 100 sorts *before* 2-digit priorities (e.g. network at 19-20).
+const INIT_START_PRIORITY = (type(_prio) === 'string' && match(_prio, /^([0-9]|[1-9][0-9])$/)) ? _prio : '99';
 uci.unload('luci-podman');
 
+// "podman" is a strict string prefix of this, so generated init scripts
+// always sort after the real /etc/init.d/podman at any tied START value.
+const INIT_SCRIPT_PREFIX = 'podman-container-';
 
 // Validators come from luci.podman_validate (imported above).
 
@@ -161,7 +166,7 @@ function to_json_body(data) {
  * @param {string} name
  */
 function init_script_path(name) {
-	return `/etc/init.d/container-${name}`;
+	return `/etc/init.d/${INIT_SCRIPT_PREFIX}${name}`;
 }
 
 // --- RPC Methods ---
@@ -850,7 +855,7 @@ const methods = {
 
 			let name = `${req.args.name}`;
 			let start_priority = `${INIT_START_PRIORITY}`;
-			let script_name = `container-${name}`;
+			let script_name = `${INIT_SCRIPT_PREFIX}${name}`;
 			let script_path = init_script_path(name);
 
 			let template = readfile('/usr/share/podman/procd-startup-template.sh');
@@ -897,7 +902,7 @@ const methods = {
 			let enabled = false;
 
 			if (exists)
-				enabled = init_enabled(`container-${req.args.name}`);
+				enabled = init_enabled(`${INIT_SCRIPT_PREFIX}${req.args.name}`);
 
 			return { exists: exists, enabled: enabled };
 		}
@@ -914,7 +919,7 @@ const methods = {
 				return { error: 'Init script not found. Generate it first.' };
 
 			let action = (req.args.enabled === true || req.args.enabled === 1) ? 'enable' : 'disable';
-			let rc = init_action(`container-${req.args.name}`, action);
+			let rc = init_action(`${INIT_SCRIPT_PREFIX}${req.args.name}`, action);
 			if (rc)
 				return { error: `Failed to ${action} service` };
 
@@ -933,7 +938,7 @@ const methods = {
 				return { success: true, message: 'Init script does not exist' };
 
 			// Disable before removing
-			init_action(`container-${req.args.name}`, 'disable');
+			init_action(`${INIT_SCRIPT_PREFIX}${req.args.name}`, 'disable');
 			unlink(script_path);
 
 			if (stat(script_path))


### PR DESCRIPTION
OpenWrt sorts /etc/rc.d/S<START><name> symlinks as plain strings, not numbers. The default init_start_priority of 100 (3 digits) can sort before 2-digit-priority services like network or Podman itself (which has a <START> value of 99), breaking intended boot order.

Changes:

Cap init_start_priority at 99 (was 100), in podman.uc.
Rename generated init scripts from container-<name> to podman-container-<name>, via a new INIT_SCRIPT_PREFIX constant. Since "podman" is a string prefix of "podman-container-<name>", it always sorts first, even at a tied priority.
Add bounded respawn (3600 5 5) to the generated instance in procd-startup-template.sh, so a slow first boot gets a few retries instead of one shot.
Update README defaults/examples accordingly.
Breaking change: existing /etc/init.d/container-<name> scripts need regenerating (old name no longer recognised). Update any sysupgrade.conf entries from container-* to podman-container-